### PR TITLE
Add ROS transport plugins

### DIFF
--- a/rtt_ros2_actionlib_msgs/CMakeLists.txt
+++ b/rtt_ros2_actionlib_msgs/CMakeLists.txt
@@ -17,10 +17,10 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(rtt_ros2_idl REQUIRED)
+find_package(rtt_ros2_interfaces REQUIRED)
 
-# generate typekit
-rtt_ros2_generate_typekit(actionlib_msgs)
+# generate typekit and transport plugins
+rtt_ros2_generate_typekit_and_transports(actionlib_msgs)
 
 # linters
 if(BUILD_TESTING)
@@ -36,5 +36,5 @@ ament_package()
 # ament_export_interfaces() or ament_export_targets() when building with
 # ament_cmake.
 orocos_generate_package(
-  DEPENDS_TARGETS rtt_ros2_idl
+  DEPENDS_TARGETS rtt_ros2_interfaces
 )

--- a/rtt_ros2_actionlib_msgs/package.xml
+++ b/rtt_ros2_actionlib_msgs/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rtt_ros2_idl</depend>
+  <depend>rtt_ros2_interfaces</depend>
   <depend>actionlib_msgs</depend>
   <depend>rtt_ros2_std_msgs</depend>
 

--- a/rtt_ros2_diagnostic_msgs/CMakeLists.txt
+++ b/rtt_ros2_diagnostic_msgs/CMakeLists.txt
@@ -17,10 +17,10 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(rtt_ros2_idl REQUIRED)
+find_package(rtt_ros2_interfaces REQUIRED)
 
-# generate typekit
-rtt_ros2_generate_typekit(diagnostic_msgs)
+# generate typekit and transport plugins
+rtt_ros2_generate_typekit_and_transports(diagnostic_msgs)
 
 # linters
 if(BUILD_TESTING)
@@ -36,5 +36,5 @@ ament_package()
 # ament_export_interfaces() or ament_export_targets() when building with
 # ament_cmake.
 orocos_generate_package(
-  DEPENDS_TARGETS rtt_ros2_idl
+  DEPENDS_TARGETS rtt_ros2_interfaces
 )

--- a/rtt_ros2_diagnostic_msgs/package.xml
+++ b/rtt_ros2_diagnostic_msgs/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rtt_ros2_idl</depend>
+  <depend>rtt_ros2_interfaces</depend>
   <depend>diagnostic_msgs</depend>
   <depend>rtt_ros2_std_msgs</depend>
   <depend>rtt_ros2_geometry_msgs</depend>

--- a/rtt_ros2_geometry_msgs/CMakeLists.txt
+++ b/rtt_ros2_geometry_msgs/CMakeLists.txt
@@ -17,10 +17,10 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(rtt_ros2_idl REQUIRED)
+find_package(rtt_ros2_interfaces REQUIRED)
 
-# generate typekit
-rtt_ros2_generate_typekit(geometry_msgs DEPENDENCIES rtt_ros2_std_msgs)
+# generate typekit and transport plugins
+rtt_ros2_generate_typekit_and_transports(geometry_msgs)
 
 # linters
 if(BUILD_TESTING)
@@ -36,5 +36,5 @@ ament_package()
 # ament_export_interfaces() or ament_export_targets() when building with
 # ament_cmake.
 orocos_generate_package(
-  DEPENDS_TARGETS rtt_ros2_idl
+  DEPENDS_TARGETS rtt_ros2_interfaces
 )

--- a/rtt_ros2_geometry_msgs/package.xml
+++ b/rtt_ros2_geometry_msgs/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rtt_ros2_idl</depend>
+  <depend>rtt_ros2_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>rtt_ros2_std_msgs</depend>
 

--- a/rtt_ros2_nav_msgs/CMakeLists.txt
+++ b/rtt_ros2_nav_msgs/CMakeLists.txt
@@ -17,12 +17,12 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(rtt_ros2_idl REQUIRED)
+find_package(rtt_ros2_interfaces REQUIRED)
 # find_package(rtt_ros2_std_msgs REQUIRED)
 # find_package(rtt_ros2_geometry_msgs REQUIRED)
 
-# generate typekit
-rtt_ros2_generate_typekit(nav_msgs)
+# generate typekit and transport plugins
+rtt_ros2_generate_typekit_and_transports(nav_msgs)
 
 # linters
 if(BUILD_TESTING)
@@ -38,5 +38,5 @@ ament_package()
 # ament_export_interfaces() or ament_export_targets() when building with
 # ament_cmake.
 orocos_generate_package(
-  DEPENDS_TARGETS rtt_ros2_idl
+  DEPENDS_TARGETS rtt_ros2_interfaces
 )

--- a/rtt_ros2_nav_msgs/package.xml
+++ b/rtt_ros2_nav_msgs/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rtt_ros2_idl</depend>
+  <depend>rtt_ros2_interfaces</depend>
   <depend>nav_msgs</depend>
   <depend>rtt_ros2_std_msgs</depend>
 

--- a/rtt_ros2_shape_msgs/CMakeLists.txt
+++ b/rtt_ros2_shape_msgs/CMakeLists.txt
@@ -17,11 +17,11 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(rtt_ros2_idl REQUIRED)
+find_package(rtt_ros2_interfaces REQUIRED)
 # find_package(rtt_ros2_geometry_msgs REQUIRED)
 
-# generate typekit
-rtt_ros2_generate_typekit(shape_msgs)
+# generate typekit and transport plugins
+rtt_ros2_generate_typekit_and_transports(shape_msgs)
 
 # linters
 if(BUILD_TESTING)
@@ -37,5 +37,5 @@ ament_package()
 # ament_export_interfaces() or ament_export_targets() when building with
 # ament_cmake.
 orocos_generate_package(
-  DEPENDS_TARGETS rtt_ros2_idl
+  DEPENDS_TARGETS rtt_ros2_interfaces
 )

--- a/rtt_ros2_shape_msgs/package.xml
+++ b/rtt_ros2_shape_msgs/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rtt_ros2_idl</depend>
+  <depend>rtt_ros2_interfaces</depend>
   <depend>shape_msgs</depend>
   <depend>rtt_ros2_geometry_msgs</depend>
 

--- a/rtt_ros2_std_msgs/CMakeLists.txt
+++ b/rtt_ros2_std_msgs/CMakeLists.txt
@@ -17,10 +17,10 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(rtt_ros2_idl REQUIRED)
+find_package(rtt_ros2_interfaces REQUIRED)
 
-# generate typekit
-rtt_ros2_generate_typekit(std_msgs)
+# generate typekit and transport plugins
+rtt_ros2_generate_typekit_and_transports(std_msgs)
 
 # linters
 if(BUILD_TESTING)
@@ -36,5 +36,5 @@ ament_package()
 # ament_export_interfaces() or ament_export_targets() when building with
 # ament_cmake.
 orocos_generate_package(
-  DEPENDS_TARGETS rtt_ros2_idl
+  DEPENDS_TARGETS rtt_ros2_interfaces
 )

--- a/rtt_ros2_std_msgs/package.xml
+++ b/rtt_ros2_std_msgs/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rtt_ros2_idl</depend>
+  <depend>rtt_ros2_interfaces</depend>
   <depend>std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/rtt_ros2_stereo_msgs/CMakeLists.txt
+++ b/rtt_ros2_stereo_msgs/CMakeLists.txt
@@ -17,10 +17,10 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(rtt_ros2_idl REQUIRED)
+find_package(rtt_ros2_interfaces REQUIRED)
 
-# generate typekit
-rtt_ros2_generate_typekit(stereo_msgs)
+# generate typekit and transport plugins
+rtt_ros2_generate_typekit_and_transports(stereo_msgs)
 
 # linters
 if(BUILD_TESTING)
@@ -36,5 +36,5 @@ ament_package()
 # ament_export_interfaces() or ament_export_targets() when building with
 # ament_cmake.
 orocos_generate_package(
-  DEPENDS_TARGETS rtt_ros2_idl
+  DEPENDS_TARGETS rtt_ros2_interfaces
 )

--- a/rtt_ros2_stereo_msgs/package.xml
+++ b/rtt_ros2_stereo_msgs/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rtt_ros2_idl</depend>
+  <depend>rtt_ros2_interfaces</depend>
   <depend>stereo_msgs</depend>
   <depend>rtt_ros2_std_msgs</depend>
   <depend>rtt_ros2_sensor_msgs</depend>

--- a/rtt_ros2_trajectory_msgs/CMakeLists.txt
+++ b/rtt_ros2_trajectory_msgs/CMakeLists.txt
@@ -17,12 +17,12 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(rtt_ros2_idl REQUIRED)
+find_package(rtt_ros2_interfaces REQUIRED)
 # find_package(rtt_ros2_geometry_msgs REQUIRED)
 # find_package(rtt_ros2_std_msgs REQUIRED)
 
-# generate typekit
-rtt_ros2_generate_typekit(trajectory_msgs)
+# generate typekit and transport plugins
+rtt_ros2_generate_typekit_and_transports(trajectory_msgs)
 
 # linters
 if(BUILD_TESTING)
@@ -38,5 +38,5 @@ ament_package()
 # ament_export_interfaces() or ament_export_targets() when building with
 # ament_cmake.
 orocos_generate_package(
-  DEPENDS_TARGETS rtt_ros2_idl
+  DEPENDS_TARGETS rtt_ros2_interfaces
 )

--- a/rtt_ros2_trajectory_msgs/package.xml
+++ b/rtt_ros2_trajectory_msgs/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rtt_ros2_idl</depend>
+  <depend>rtt_ros2_interfaces</depend>
   <depend>trajectory_msgs</depend>
   <depend>rtt_ros2_geometry_msgs</depend>
   <depend>rtt_ros2_std_msgs</depend>

--- a/rtt_ros2_visualization_msgs/CMakeLists.txt
+++ b/rtt_ros2_visualization_msgs/CMakeLists.txt
@@ -17,10 +17,10 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(rtt_ros2_idl REQUIRED)
+find_package(rtt_ros2_interfaces REQUIRED)
 
-# generate typekit
-rtt_ros2_generate_typekit(visualization_msgs)
+# generate typekit and transport plugins
+rtt_ros2_generate_typekit_and_transports(visualization_msgs)
 
 # linters
 if(BUILD_TESTING)
@@ -36,5 +36,5 @@ ament_package()
 # ament_export_interfaces() or ament_export_targets() when building with
 # ament_cmake.
 orocos_generate_package(
-  DEPENDS_TARGETS rtt_ros2_idl
+  DEPENDS_TARGETS rtt_ros2_interfaces
 )

--- a/rtt_ros2_visualization_msgs/package.xml
+++ b/rtt_ros2_visualization_msgs/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rtt_ros2_idl</depend>
+  <depend>rtt_ros2_interfaces</depend>
   <depend>visualization_msgs</depend>
   <depend>rtt_ros2_geometry_msgs</depend>
   <depend>rtt_ros2_std_msgs</depend>


### PR DESCRIPTION
... and depend on `rtt_ros2_interfaces` instead of `rtt_ros2_idl`, such that all packages build a typekit and ROS transport plugin.

Depends on https://github.com/orocos/rtt_ros2_integration/pull/10.