### PR TITLE
Remove incomplete find_package() calls for typekits of interface package dependencies

### DIFF
--- a/rtt_ros2_actionlib_msgs/package.xml
+++ b/rtt_ros2_actionlib_msgs/package.xml
@@ -11,7 +11,6 @@
 
   <depend>rtt_ros2_idl</depend>
   <depend>actionlib_msgs</depend>
-  <depend>rtt_ros2_std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rtt_ros2_diagnostic_msgs/package.xml
+++ b/rtt_ros2_diagnostic_msgs/package.xml
@@ -11,8 +11,6 @@
 
   <depend>rtt_ros2_idl</depend>
   <depend>diagnostic_msgs</depend>
-  <depend>rtt_ros2_std_msgs</depend>
-  <depend>rtt_ros2_geometry_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rtt_ros2_geometry_msgs/CMakeLists.txt
+++ b/rtt_ros2_geometry_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_idl REQUIRED)
 
 # generate typekit
-rtt_ros2_generate_typekit(geometry_msgs DEPENDENCIES rtt_ros2_std_msgs)
+rtt_ros2_generate_typekit(geometry_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_geometry_msgs/package.xml
+++ b/rtt_ros2_geometry_msgs/package.xml
@@ -11,7 +11,6 @@
 
   <depend>rtt_ros2_idl</depend>
   <depend>geometry_msgs</depend>
-  <depend>rtt_ros2_std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rtt_ros2_nav_msgs/CMakeLists.txt
+++ b/rtt_ros2_nav_msgs/CMakeLists.txt
@@ -18,8 +18,6 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_idl REQUIRED)
-# find_package(rtt_ros2_std_msgs REQUIRED)
-# find_package(rtt_ros2_geometry_msgs REQUIRED)
 
 # generate typekit
 rtt_ros2_generate_typekit(nav_msgs)

--- a/rtt_ros2_nav_msgs/package.xml
+++ b/rtt_ros2_nav_msgs/package.xml
@@ -11,7 +11,6 @@
 
   <depend>rtt_ros2_idl</depend>
   <depend>nav_msgs</depend>
-  <depend>rtt_ros2_std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rtt_ros2_sensor_msgs/package.xml
+++ b/rtt_ros2_sensor_msgs/package.xml
@@ -11,8 +11,6 @@
 
   <depend>rtt_ros2_idl</depend>
   <depend>sensor_msgs</depend>
-  <depend>rtt_ros2_std_msgs</depend>
-  <depend>rtt_ros2_geometry_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rtt_ros2_shape_msgs/CMakeLists.txt
+++ b/rtt_ros2_shape_msgs/CMakeLists.txt
@@ -18,7 +18,6 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_idl REQUIRED)
-# find_package(rtt_ros2_geometry_msgs REQUIRED)
 
 # generate typekit
 rtt_ros2_generate_typekit(shape_msgs)

--- a/rtt_ros2_stereo_msgs/package.xml
+++ b/rtt_ros2_stereo_msgs/package.xml
@@ -11,8 +11,6 @@
 
   <depend>rtt_ros2_idl</depend>
   <depend>stereo_msgs</depend>
-  <depend>rtt_ros2_std_msgs</depend>
-  <depend>rtt_ros2_sensor_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rtt_ros2_trajectory_msgs/CMakeLists.txt
+++ b/rtt_ros2_trajectory_msgs/CMakeLists.txt
@@ -18,8 +18,6 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_idl REQUIRED)
-# find_package(rtt_ros2_geometry_msgs REQUIRED)
-# find_package(rtt_ros2_std_msgs REQUIRED)
 
 # generate typekit
 rtt_ros2_generate_typekit(trajectory_msgs)

--- a/rtt_ros2_trajectory_msgs/package.xml
+++ b/rtt_ros2_trajectory_msgs/package.xml
@@ -11,8 +11,6 @@
 
   <depend>rtt_ros2_idl</depend>
   <depend>trajectory_msgs</depend>
-  <depend>rtt_ros2_geometry_msgs</depend>
-  <depend>rtt_ros2_std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rtt_ros2_visualization_msgs/package.xml
+++ b/rtt_ros2_visualization_msgs/package.xml
@@ -11,8 +11,6 @@
 
   <depend>rtt_ros2_idl</depend>
   <depend>visualization_msgs</depend>
-  <depend>rtt_ros2_geometry_msgs</depend>
-  <depend>rtt_ros2_std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
If needed, dependency tracking should be handled by the `generate_typekit()` cmake function in [rtt_ros2_idl](https://github.com/orocos/rtt_ros2_integration/blob/master/rtt_ros2_idl/cmake/rtt_ros2_idl_generate_typekit.cmake) directly.

The current `find_package()` calls for dependency typekit packages were incomplete. Almost all packages in [common_interfaces](https://github.com/ros2/common_interfaces) depend on `std_msgs`, and some also on `geometry_msgs`, and `std_msgs` itself depends on `builtin_interfaces`.

But it is not required that typekits are built in dependency order of the underlying interface packages nor that one typekit library links to another. So there is no build dependency that must be reflected in `CMakeLists.txt` files. There is only a run-time dependency such that the RTT type system can also find type information for the types of nested fields, which can be declared with the [rtt_ros2_plugin_depend()](https://github.com/orocos/rtt_ros2_integration/blob/master/rtt_ros2/cmake/rtt_ros2_export_plugin_depend.cmake) cmake function provided by package [rtt_ros2](https://github.com/orocos/rtt_ros2_integration/tree/master/rtt_ros2). However, this can be done in `generate_typekit()` by looking up dependencies of interface packages in the [ament resource index](https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resource_index.md). It is not needed anymore that a typekit package depends on typekit packages for nested message types explicitly, like in [rtt_ros_integration](https://github.com/orocos/rtt_ros_integration/tree/toolchain-2.9/rtt_roscomm) for ROS 1.

I will propose another patch to [rtt_ros2_integration](https://github.com/orocos/rtt_ros2_integration) which adds this functionality to `rtt_ros2_idl`.