### PR TITLE
Enable Travis CI for this repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ cache:
 git:
   quiet: true # optional, silences the cloning of the target repository
 
+# limit automatic builds to certain branches (and pull requests)
+branches:
+  only:
+  - master
+
 # configure the build environment(s)
 # https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#variables-you-can-configure
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
+
+language: generic # optional, just removes the language badge
+
+services:
+  - docker
+
+# include the following block if the C/C++ build artifacts should get cached by Travis,
+# CCACHE_DIR needs to get set as well to actually fill the cache
+cache:
+  directories:
+    - $HOME/.ccache
+
+git:
+  quiet: true # optional, silences the cloning of the target repository
+
+# configure the build environment(s)
+# https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#variables-you-can-configure
+env:
+  global: # global settings for all jobs
+    - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
+    - ROSDEP_SKIP_KEYS="log4cpp rtt ocl" # preinstalled in the docker images
+    - UPSTREAM_WORKSPACE="github:orocos/rtt_ros2_integration#master"
+  matrix: # each line is a job
+    - ROS_DISTRO="dashing" DOCKER_IMAGE="orocos/ros2:dashing-ros-base-bionic"
+    - ROS_DISTRO="eloquent" DOCKER_IMAGE="orocos/ros2:eloquent-ros-base-bionic"
+    - ROS_DISTRO="foxy" DOCKER_IMAGE="orocos/ros2:foxy-ros-base-focal"
+
+# allow failures, e.g. for unsupported distros
+# matrix:
+#   allow_failures:
+#     - env: ROS_DISTRO="lunar" ROS_REPO=ros-shadow-fixed
+
+# clone and run industrial_ci
+install:
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
+script:
+  - .industrial_ci/travis.sh

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
+# Orocos RTT typekits for `common_interfaces`
 
-# Orocos RTT typekit for `common_interfaces`
+[![Build Status](https://travis-ci.org/orocos/rtt_ros2_common_interfaces.svg?branch=master)](https://travis-ci.org/orocos/rtt_ros2_common_interfaces)
 
-This package provides typekits for the messages distributed by
-[`common_interfaces`](https://github.com/ros2/common_interfaces) ROS 2 package.
+This repository provides typekits for the messages and service packages that are part of the
+[`common_interfaces`](https://github.com/ros2/common_interfaces) set.
 
 ## Contributing
 


### PR DESCRIPTION
This is basically a copy of [.travis.yml](https://github.com/orocos/rtt_ros2_integration/blob/4dedab742a18649ce2fc669b0a3c606155ac827c/.travis.yml) from [rtt_ros2_integration@4dedab7](https://github.com/orocos/rtt_ros2_integration/tree/4dedab742a18649ce2fc669b0a3c606155ac827c), with an additional `UPSTREAM_WORKSPACE` configuration pointing to branch master of rtt_ros2_integration.