### PR TITLE
Use renamed macro rtt_ros2_generate_interfaces_plugins() provided by rtt_ros2_interfaces

### DIFF
--- a/rtt_ros2_actionlib_msgs/CMakeLists.txt
+++ b/rtt_ros2_actionlib_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_typekit_and_transports(actionlib_msgs)
+rtt_ros2_generate_interface_plugins(actionlib_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_actionlib_msgs/CMakeLists.txt
+++ b/rtt_ros2_actionlib_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_interface_plugins(actionlib_msgs)
+rtt_ros2_generate_interfaces_plugins(actionlib_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_diagnostic_msgs/CMakeLists.txt
+++ b/rtt_ros2_diagnostic_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_typekit_and_transports(diagnostic_msgs)
+rtt_ros2_generate_interface_plugins(diagnostic_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_diagnostic_msgs/CMakeLists.txt
+++ b/rtt_ros2_diagnostic_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_interface_plugins(diagnostic_msgs)
+rtt_ros2_generate_interfaces_plugins(diagnostic_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_geometry_msgs/CMakeLists.txt
+++ b/rtt_ros2_geometry_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_interface_plugins(geometry_msgs)
+rtt_ros2_generate_interfaces_plugins(geometry_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_geometry_msgs/CMakeLists.txt
+++ b/rtt_ros2_geometry_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_typekit_and_transports(geometry_msgs)
+rtt_ros2_generate_interface_plugins(geometry_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_nav_msgs/CMakeLists.txt
+++ b/rtt_ros2_nav_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_typekit_and_transports(nav_msgs)
+rtt_ros2_generate_interface_plugins(nav_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_nav_msgs/CMakeLists.txt
+++ b/rtt_ros2_nav_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_interface_plugins(nav_msgs)
+rtt_ros2_generate_interfaces_plugins(nav_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_shape_msgs/CMakeLists.txt
+++ b/rtt_ros2_shape_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_interface_plugins(shape_msgs)
+rtt_ros2_generate_interfaces_plugins(shape_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_shape_msgs/CMakeLists.txt
+++ b/rtt_ros2_shape_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_typekit_and_transports(shape_msgs)
+rtt_ros2_generate_interface_plugins(shape_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_std_msgs/CMakeLists.txt
+++ b/rtt_ros2_std_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_interface_plugins(std_msgs)
+rtt_ros2_generate_interfaces_plugins(std_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_std_msgs/CMakeLists.txt
+++ b/rtt_ros2_std_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_typekit_and_transports(std_msgs)
+rtt_ros2_generate_interface_plugins(std_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_stereo_msgs/CMakeLists.txt
+++ b/rtt_ros2_stereo_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_typekit_and_transports(stereo_msgs)
+rtt_ros2_generate_interface_plugins(stereo_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_stereo_msgs/CMakeLists.txt
+++ b/rtt_ros2_stereo_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_interface_plugins(stereo_msgs)
+rtt_ros2_generate_interfaces_plugins(stereo_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_trajectory_msgs/CMakeLists.txt
+++ b/rtt_ros2_trajectory_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_typekit_and_transports(trajectory_msgs)
+rtt_ros2_generate_interface_plugins(trajectory_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_trajectory_msgs/CMakeLists.txt
+++ b/rtt_ros2_trajectory_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_interface_plugins(trajectory_msgs)
+rtt_ros2_generate_interfaces_plugins(trajectory_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_visualization_msgs/CMakeLists.txt
+++ b/rtt_ros2_visualization_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_interface_plugins(visualization_msgs)
+rtt_ros2_generate_interfaces_plugins(visualization_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/rtt_ros2_visualization_msgs/CMakeLists.txt
+++ b/rtt_ros2_visualization_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
 # generate typekit and transport plugins
-rtt_ros2_generate_typekit_and_transports(visualization_msgs)
+rtt_ros2_generate_interface_plugins(visualization_msgs)
 
 # linters
 if(BUILD_TESTING)


### PR DESCRIPTION
Related to https://github.com/orocos/rtt_ros2_integration/pull/21.