### PR TITLE
Add package rtt_ros2_std_srvs

### DIFF
--- a/rtt_ros2_std_srvs/CMakeLists.txt
+++ b/rtt_ros2_std_srvs/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.5)
+project(rtt_ros2_std_srvs CXX)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+# if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+#   add_compile_options(-Wall -Wextra -Wpedantic)
+# endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rtt_ros2_interfaces REQUIRED)
+
+# generate typekit and transport plugins
+include_directories(include/orocos)
+rtt_ros2_generate_interfaces_plugins(std_srvs
+  EXTRA_INCLUDES
+    ${PROJECT_NAME}/empty.hpp
+    ${PROJECT_NAME}/set_bool.hpp
+    ${PROJECT_NAME}/trigger.hpp
+)
+
+# linters
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+# must be called *after* the targets to check exported libraries etc.
+ament_package()
+
+# orocos_generate_package() is deprecated for ROS 2.
+# Prefer cmake target export and import instead, in combination with
+# ament_export_interfaces() or ament_export_targets() when building with
+# ament_cmake.
+orocos_generate_package(
+  DEPENDS_TARGETS rtt_ros2_interfaces
+)

--- a/rtt_ros2_std_srvs/include/orocos/rtt_ros2_std_srvs/empty.hpp
+++ b/rtt_ros2_std_srvs/include/orocos/rtt_ros2_std_srvs/empty.hpp
@@ -1,0 +1,52 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_STD_SRVS__EMPTY_HPP_
+#define OROCOS__RTT_ROS2_STD_SRVS__EMPTY_HPP_
+
+#include <memory>
+#include <string>
+
+#include "rtt_ros2_services/rtt_ros2_services_proxy.hpp"
+#include "std_srvs/srv/empty.h"
+
+// Specialized implementations of RosServiceServerOperationCallerWrapper for std_srvs/srv/Empty.
+//
+// Accepted signatures:
+//  - bool empty(Request&, Response&) // the default signature
+//  - void empty()
+//
+
+namespace rtt_ros2_services
+{
+
+template<>
+struct RosServiceServerOperationCallerWrapper<std_srvs::srv::Empty, 1>
+{
+  typedef void Signature ();
+  typedef RTT::OperationCaller<Signature> ProxyOperationCallerType;
+  template<typename Callable>
+  static void dispatch(
+    Callable & call,
+    std::shared_ptr<rmw_request_id_t>,
+    std_srvs::srv::Empty::Request::SharedPtr,
+    std_srvs::srv::Empty::Response::SharedPtr)
+  {
+    call();
+  }
+};
+
+}  // namespace rtt_ros2_services
+
+#endif  // OROCOS__RTT_ROS2_STD_SRVS__EMPTY_HPP_

--- a/rtt_ros2_std_srvs/include/orocos/rtt_ros2_std_srvs/set_bool.hpp
+++ b/rtt_ros2_std_srvs/include/orocos/rtt_ros2_std_srvs/set_bool.hpp
@@ -1,0 +1,105 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_STD_SRVS__SET_BOOL_HPP_
+#define OROCOS__RTT_ROS2_STD_SRVS__SET_BOOL_HPP_
+
+#include <memory>
+#include <string>
+
+#include "rtt_ros2_services/rtt_ros2_services_proxy.hpp"
+#include "std_srvs/srv/set_bool.h"
+
+// Specialized implementation of RosServiceServerOperationCallerWrapper for std_srvs/srv/SetBool.
+//
+// Accepted signatures:
+//  - bool setBool(Request&, Response&) // the default signature
+//  - bool setBool(bool, std::string &message_out)
+//  - bool setBool(bool) // response.message will be empty
+//  - std::string setBool(bool) // response.success = true
+//  - void setBool(bool) // response.success = true and response.message will be empty
+//
+
+namespace rtt_ros2_services
+{
+
+template<>
+struct RosServiceServerOperationCallerWrapper<std_srvs::srv::SetBool, 1>
+{
+  typedef bool Signature (bool, std::string &);
+  typedef RTT::OperationCaller<Signature> ProxyOperationCallerType;
+  template<typename Callable>
+  static void dispatch(
+    Callable & call,
+    std::shared_ptr<rmw_request_id_t>,
+    std_srvs::srv::SetBool::Request::SharedPtr request,
+    std_srvs::srv::SetBool::Response::SharedPtr response)
+  {
+    response->success = call(request->data, response->message);
+  }
+};
+
+template<>
+struct RosServiceServerOperationCallerWrapper<std_srvs::srv::SetBool, 2>
+{
+  typedef bool Signature (bool);
+  typedef RTT::OperationCaller<Signature> ProxyOperationCallerType;
+  template<typename Callable>
+  static void dispatch(
+    Callable & call,
+    std::shared_ptr<rmw_request_id_t>,
+    std_srvs::srv::SetBool::Request::SharedPtr request,
+    std_srvs::srv::SetBool::Response::SharedPtr response)
+  {
+    response->success = call(request->data);
+  }
+};
+
+template<>
+struct RosServiceServerOperationCallerWrapper<std_srvs::srv::SetBool, 3>
+{
+  typedef std::string Signature (bool);
+  typedef RTT::OperationCaller<Signature> ProxyOperationCallerType;
+  template<typename Callable>
+  static void dispatch(
+    Callable & call,
+    std::shared_ptr<rmw_request_id_t>,
+    std_srvs::srv::SetBool::Request::SharedPtr request,
+    std_srvs::srv::SetBool::Response::SharedPtr response)
+  {
+    response->message = call(request->data);
+    response->success = true;
+  }
+};
+
+template<>
+struct RosServiceServerOperationCallerWrapper<std_srvs::srv::SetBool, 4>
+{
+  typedef void Signature (bool);
+  typedef RTT::OperationCaller<Signature> ProxyOperationCallerType;
+  template<typename Callable>
+  static void dispatch(
+    Callable & call,
+    std::shared_ptr<rmw_request_id_t>,
+    std_srvs::srv::SetBool::Request::SharedPtr request,
+    std_srvs::srv::SetBool::Response::SharedPtr response)
+  {
+    call(request->data);
+    response->success = true;
+  }
+};
+
+}  // namespace rtt_ros2_services
+
+#endif  // OROCOS__RTT_ROS2_STD_SRVS__SET_BOOL_HPP_

--- a/rtt_ros2_std_srvs/include/orocos/rtt_ros2_std_srvs/trigger.hpp
+++ b/rtt_ros2_std_srvs/include/orocos/rtt_ros2_std_srvs/trigger.hpp
@@ -1,0 +1,87 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_STD_SRVS__TRIGGER_HPP_
+#define OROCOS__RTT_ROS2_STD_SRVS__TRIGGER_HPP_
+
+#include <memory>
+#include <string>
+
+#include "rtt_ros2_services/rtt_ros2_services_proxy.hpp"
+#include "std_srvs/srv/trigger.hpp"
+
+// Specialized implementations of RosServiceServerOperationCallerWrapper for std_srvs/srv/Trigger.
+//
+// Accepted signatures:
+//  - bool trigger(Request&, Response&) // the default signature
+//  - bool trigger(std::string &message_out)
+//  - bool trigger() // response->message will be empty
+//  - std::string trigger() // response->success = true
+//
+
+namespace rtt_ros2_services
+{
+
+template<>
+struct RosServiceServerOperationCallerWrapper<std_srvs::srv::Trigger, 1>
+{
+  typedef bool Signature (std::string & message_out);
+  typedef RTT::OperationCaller<Signature> ProxyOperationCallerType;
+  template<typename Callable>
+  static void dispatch(
+    Callable & call,
+    std::shared_ptr<rmw_request_id_t>,
+    std_srvs::srv::Trigger::Request::SharedPtr request,
+    std_srvs::srv::Trigger::Response::SharedPtr response)
+  {
+    response->success = call(response->message);
+  }
+};
+
+template<>
+struct RosServiceServerOperationCallerWrapper<std_srvs::srv::Trigger, 2>
+{
+  typedef bool Signature ();
+  typedef RTT::OperationCaller<Signature> ProxyOperationCallerType;
+  template<typename Callable>
+  static void dispatch(
+    Callable & call,
+    std::shared_ptr<rmw_request_id_t>,
+    std_srvs::srv::Trigger::Request::SharedPtr request,
+    std_srvs::srv::Trigger::Response::SharedPtr response)
+  {
+    response->success = call();
+  }
+};
+
+template<>
+struct RosServiceServerOperationCallerWrapper<std_srvs::srv::Trigger, 3>
+{
+  typedef std::string Signature ();
+  typedef RTT::OperationCaller<Signature> ProxyOperationCallerType;
+  template<typename Callable>
+  static void dispatch(
+    Callable & call,
+    std::shared_ptr<rmw_request_id_t>,
+    std_srvs::srv::Trigger::Request::SharedPtr request,
+    std_srvs::srv::Trigger::Response::SharedPtr response)
+  {
+    response->message = call();
+    response->success = true;
+  }
+};
+
+}  // namespace rtt_ros2_services
+
+#endif  // OROCOS__RTT_ROS2_STD_SRVS__TRIGGER_HPP_

--- a/rtt_ros2_std_srvs/package.xml
+++ b/rtt_ros2_std_srvs/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rtt_ros2_std_srvs</name>
+  <version>0.0.0</version>
+  <description>RTT typekit and ROS service plugin for std_srvs</description>
+  <maintainer email="orocos-dev@orocos.org">Orocos Developers</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rtt_ros2_interfaces</depend>
+  <depend>std_srvs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
`rtt_ros2_std_srvs` provides Orocos support for connecting std_srvs ROS services to Orocos operations and operation callers.
Depends on https://github.com/orocos/rtt_ros2_integration/pull/23.