### PR TITLE
.travis.yml: switch to orocos/ros2-ci Docker images without preinstalled rtt_ros2_integration for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,12 @@ env:
   global: # global settings for all jobs
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
     - ROSDEP_SKIP_KEYS="log4cpp rtt ocl" # preinstalled in the docker images
+    - AFTER_INIT_EMBED="source /opt/orocos/\${ROS_DISTRO}/setup.sh"
     - UPSTREAM_WORKSPACE="github:orocos/rtt_ros2_integration#master"
   matrix: # each line is a job
-    - ROS_DISTRO="dashing" DOCKER_IMAGE="orocos/ros2:dashing-ros-base-bionic"
-    - ROS_DISTRO="eloquent" DOCKER_IMAGE="orocos/ros2:eloquent-ros-base-bionic"
-    - ROS_DISTRO="foxy" DOCKER_IMAGE="orocos/ros2:foxy-ros-base-focal"
+    - ROS_DISTRO="dashing" DOCKER_IMAGE="orocos/ros2-ci:dashing-ros-base-bionic"
+    - ROS_DISTRO="eloquent" DOCKER_IMAGE="orocos/ros2-ci:eloquent-ros-base-bionic"
+    - ROS_DISTRO="foxy" DOCKER_IMAGE="orocos/ros2-ci:foxy-ros-base-focal"
 
 # allow failures, e.g. for unsupported distros
 # matrix:


### PR DESCRIPTION
Same as https://github.com/orocos/rtt_ros2_integration/pull/26 for  [rtt_ros2_integration](https://github.com/orocos/rtt_ros2_integration):

> Once [orocos/orocos-docker-images#3](https://github.com/orocos/orocos-docker-images/pull/3) has been merged and the issues with automated builds on Docker Hub have been solved, the [orocos/ros2](https://hub.docker.com/r/orocos/ros2/tags) images will have rtt_ros2_integration and rtt_ros2_common_interfaces preinstalled. This might be bad for CI testing of those two repos, if older versions of the packages to be tested are preinstalled in an underlay.
> 
> Therefore a new Docker repository [orocos/ros2-ci](https://hub.docker.com/r/orocos/ros2-ci/tags) has been created, whose images are equivalent to the ones in [orocos/ros2](https://hub.docker.com/r/orocos/ros2/tags) (after [orocos/orocos-docker-images#3](https://github.com/orocos/orocos-docker-images/pull/3)) but stop at the `orocos_toolchain` target and hence only have the Orocos Toolchain packages preinstalled.
> 
> A fundamental difference compared to the previous images is that the Orocos Toolchain and ROS integration packages are installed to `/opt/orocos/${ROS_DISTRO}` now and not to `/opt/ros/${ROS_DISTRO}`. The main purpose of this pull request is to verify whether [industrial_ci](https://github.com/ros-industrial/industrial_ci) can deal with that. [industrial_ci/src/tests/source_tests.sh](https://github.com/ros-industrial/industrial_ci/blob/b9a029fb18de49065e9a54ff6d8c42420cfe4931/industrial_ci/src/tests/source_tests.sh#L118) only extends `/opt/ros/${ROS_DISTRO}` and there is no [configuration variable](https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#variables-you-can-configure) to change that, but `/opt/orocos/${ROS_DISTRO}` is already sourced in the [orocos_entrypoint.sh](https://github.com/orocos/orocos-docker-images/pull/3/files#diff-7b039399f9b87c714b81743065a79b13) script and hence the required variables should be already set (`CMAKE_PREFIX_PATH`, `LD_LIBRARY_PATH`, `OROCOS_TARGET`, ...).
> 
> The current set of images in [orocos/ros2-ci](https://hub.docker.com/r/orocos/ros2-ci/tags) have been built and pushed manually because automated builds for [orocos/orocos-docker-images#3](https://github.com/orocos/orocos-docker-images/pull/3) on Docker Hub still fail, likely because of resource constraints.

